### PR TITLE
Added two way binding and skeleton for loading

### DIFF
--- a/src/components/AdminComponent/Overview.jsx
+++ b/src/components/AdminComponent/Overview.jsx
@@ -13,14 +13,44 @@ import {
 } from "../../firebase/NannyFunctions";
 import { getParentCount } from "@/firebase/ParentFunctions";
 
-function Overview() {
+import { Link } from "react-router-dom";
+
+import verifiedNannies from "./VerifiedNannies";
+import PendingVerifications from "./PendingVerifications";
+
+import CustomLoading from "../EssentialComponents/CustomLoading";
+
+import { Skeleton } from "@/components/ui/skeleton"
+
+
+// Creating a two way binding with changeTab
+function Overview({ changeTab }) {
   const [verified, setVerified] = useState(null);
   const [unVerified, setUnVerified] = useState(null);
   const [parentTotal, setParentTotal] = useState(null);
 
+  // Adding a loader
+
+  const [isLoading, setIsLoading] = useState(true)
+
+
+  const handleCardClick = (cardValue) => {
+    changeTab(cardValue);
+  };
+
+  // Reference: https://ui.shadcn.com/docs/components/skeleton
+
+  const SkeletonCard = () => (
+    <div className="p-4 border shadow rounded-md">
+      <Skeleton className="h-6 w-3/4 mb-4" /> 
+      <Skeleton className="h-12 w-full" />
+    </div>
+  );
+
   useEffect(() => {
     const fetchVerifies = async () => {
       try {
+        setIsLoading(true)
         const verifiedCount = await getVerifiedCount();
         const unVerifiedCount = await getNonVerifiedCount();
         const parentCount = await getParentCount();
@@ -29,29 +59,45 @@ function Overview() {
         setParentTotal(parentCount);
       } catch (error) {
         console.error("Error fetching counts:", error);
+      }finally{
+        setIsLoading(false)
       }
     };
     fetchVerifies();
   }, []);
 
+  if(isLoading){
+    return (
+      <div>
+        <div className="p-4">Overview</div>
+        <div className="grid gap-4 md:grid-cols-4">
+          <SkeletonCard />
+          <SkeletonCard />
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div>
-      <div>Overview</div>
-      <div className="grid gap-4 md:grid-cols-3">
-        <Card>
-          <CardHeader>
-            <CardTitle>Unverified Nannies</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-2xl">{unVerified}</p>
-          </CardContent>
-        </Card>
-        <Card>
+      <div className="p-4">Overview</div>
+      <div className="grid gap-4 md:grid-cols-4">
+        <Card onClick={() => handleCardClick("VerifiedNannies")}>
           <CardHeader>
             <CardTitle>Verified Nannies</CardTitle>
           </CardHeader>
           <CardContent>
             <p className="text-2xl">{verified}</p>
+          </CardContent>
+        </Card>
+        <Card onClick={() => handleCardClick("PendingVerifications")}>
+          <CardHeader>
+            <CardTitle>Unverified Nannies</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl">{unVerified}</p>
           </CardContent>
         </Card>
         <Card>

--- a/src/components/Dashboard/AdminDashboard.jsx
+++ b/src/components/Dashboard/AdminDashboard.jsx
@@ -7,8 +7,16 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 const AdminDashboard = ({ userRole }) => {
   const [tabValue, setTabValue] = useState("Overview");
 
-// For dashboard design i referred -> https://ui.shadcn.com/examples/dashboard
-// and https://github.com/shadcn-ui/ui/blob/main/apps/www/app/examples/dashboard/page.tsx
+  // For dashboard design i referred -> https://ui.shadcn.com/examples/dashboard
+  // and https://github.com/shadcn-ui/ui/blob/main/apps/www/app/examples/dashboard/page.tsx
+
+  // referece for two way binding: https://handsontable.com/blog/understanding-data-binding-in-react#:~:text=Two%2Dway%20data%20binding%20allows,is%20achieved%20using%20controlled%20components.
+
+  // Creating a two way binding for setting the tabs value
+  // Function to change the tab value
+  const changeTab = (newTabValue) => {
+    setTabValue(newTabValue);
+  };
 
   return (
     <div className="min-h-screen p-6">
@@ -20,7 +28,7 @@ const AdminDashboard = ({ userRole }) => {
           <TabsTrigger value="PendingVerifications" className="text-current">Pending Verifications</TabsTrigger>
         </TabsList>
         <TabsContent value="Overview">
-          <Overview />
+          <Overview changeTab={changeTab} />
         </TabsContent>
         <TabsContent value="VerifiedNannies">
           <VerifiedNannies />


### PR DESCRIPTION
I created a two way binding between the overview card title (verified and unverfied nannies), so if the admin clicks on any of these cards, it sends the card clicked value back to the AdminDashboard tab value and will update the tab value to link or render that component which is linked to the tab

referece: https://handsontable.com/blog/understanding-data-binding-in-react#:~:text=Two%2Dway%20data%20binding%20allows,is%20achieved%20using%20controlled%20components.

I used SHADCN UI skeliton for showing the loading of cards to make the ui look consistent and good

Reference: https://ui.shadcn.com/docs/components/skeleton